### PR TITLE
Update dependencies and remove warnings/logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Execution of the Java variant
 
-`mvn package exec:java -Dexec.mainClass=de.tuberlin.deem.tht.TaskJava`
+`mvn package exec:java -Dexec.mainClass=de.tuberlin.deem.tht.TaskJava -Dexec.cleanupDaemonThreads=false`
 
 
 ### Hints

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,27 @@
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.major.version}</artifactId>
             <version>3.5.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -35,6 +51,26 @@
             <artifactId>spark-sql_${scala.major.version}</artifactId>
             <version>3.5.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>
@@ -74,6 +110,15 @@
                 <version>2.7</version>
                 <configuration>
                     <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/scala/de/tuberlin/deem/tht/TaskJava.java
+++ b/src/main/scala/de/tuberlin/deem/tht/TaskJava.java
@@ -14,6 +14,8 @@ public class TaskJava {
 
         SparkSession session = null;
 
+        handleIllegalReflectiveAccessSpark();
+
         try {
             session = SparkSession.builder()
                 .master("local")
@@ -29,5 +31,18 @@ public class TaskJava {
             session.stop();
             System.clearProperty("spark.driver.port");
         }
+    }
+
+    public static void handleIllegalReflectiveAccessSpark(){
+        Module pf = org.apache.spark.unsafe.Platform.class.getModule();
+        Target.class.getModule().addOpens("java.nio", pf);
+        Target.class.getModule().addOpens("java.io", pf);
+
+        Module se = org.apache.spark.util.SizeEstimator.class.getModule();
+        Target.class.getModule().addOpens("java.util", se);
+        Target.class.getModule().addOpens("java.net", se);
+        Target.class.getModule().addOpens("java.lang", se);
+        Target.class.getModule().addOpens("java.lang.ref", se);
+        Target.class.getModule().addOpens("java.util.concurrent", se);
     }
 }


### PR DESCRIPTION
This PR updates the Hadoop version and dependency and excludes the one contained in Spark, adds dependencies for Spark Dataset, and fixes Java 11+ unsafe memory warning for Spark.
Additionally, it overrules the logging from Spark to silent it. 